### PR TITLE
Add Supabase SQL history, baseline guardrails, sanity checks

### DIFF
--- a/supabase/archive/001_policies_messages.sql
+++ b/supabase/archive/001_policies_messages.sql
@@ -1,0 +1,105 @@
+-- 004_policies_messages.sql
+-- Purpose: Insert/update/select policies for messages, message_tags, and message_contacts
+-- Date: 2025-08-15
+-- Notes:
+--   - Uses DROP POLICY IF EXISTS to stay idempotent
+--   - Assumes RLS is already enabled on these tables (see 002_messages.sql)
+
+-- ========== public.messages INSERT policies ==========
+
+drop policy if exists "Admins can insert any message" on public.messages;
+create policy "Admins can insert any message"
+on public.messages for insert
+to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+drop policy if exists "Clients can insert their own shared/public messages" on public.messages;
+create policy "Clients can insert their own shared/public messages"
+on public.messages for insert
+to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.client_id = public.messages.client_id
+  )
+  and public.messages.visibility in ('shared','public')
+);
+
+-- ========== public.message_tags SELECT/INSERT policies ==========
+
+drop policy if exists "Admins read all tags" on public.message_tags;
+create policy "Admins read all tags"
+on public.message_tags for select
+to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+drop policy if exists "Clients read tags for their visible messages" on public.message_tags;
+create policy "Clients read tags for their visible messages"
+on public.message_tags for select
+to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.client_id = (select m.client_id from public.messages m where m.id = public.message_tags.message_id)
+  )
+);
+
+drop policy if exists "Admins can tag any message" on public.message_tags;
+create policy "Admins can tag any message"
+on public.message_tags for insert
+to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+-- ========== public.message_contacts SELECT/UPDATE policies ==========
+
+drop policy if exists "Admins read all message_contacts" on public.message_contacts;
+create policy "Admins read all message_contacts"
+on public.message_contacts for select
+to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+drop policy if exists "Clients read their own recipient rows" on public.message_contacts;
+create policy "Clients read their own recipient rows"
+on public.message_contacts for select
+to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.contact_id = public.message_contacts.contact_id
+  )
+);
+
+drop policy if exists "Contacts can mark their reads" on public.message_contacts;
+create policy "Contacts can mark their reads"
+on public.message_contacts for update
+to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.contact_id = public.message_contacts.contact_id
+  )
+)
+with check (true);

--- a/supabase/archive/002_policy_message_contacts_insert.sql
+++ b/supabase/archive/002_policy_message_contacts_insert.sql
@@ -1,0 +1,16 @@
+-- 005_policy_message_contacts_insert.sql
+-- Purpose: Allow a user to INSERT a recipient row for themselves in public.message_contacts
+-- Date: 2025-08-15
+-- Notes: Idempotent via DROP POLICY IF EXISTS
+
+drop policy if exists "Contacts can insert their own recipient rows" on public.message_contacts;
+create policy "Contacts can insert their own recipient rows"
+on public.message_contacts for insert
+to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.contact_id = public.message_contacts.contact_id
+  )
+);

--- a/supabase/archive/README.md
+++ b/supabase/archive/README.md
@@ -1,0 +1,6 @@
+# supabase/archive
+
+Contains **older or superseded SQL scripts** kept for reference.
+
+- Useful for rollback or comparing schema changes.
+- Do not re-apply unless intentionally restoring old behavior.

--- a/supabase/debug/001_select_user_profiles_debug.sql
+++ b/supabase/debug/001_select_user_profiles_debug.sql
@@ -1,0 +1,4 @@
+select up.id, up.client_id, up.contact_id, up.role, u.email
+from public.user_profiles up
+join auth.users u on u.id = up.id
+where u.email = 'daniel@test.com';

--- a/supabase/debug/002_promote_user_to_manager.sql
+++ b/supabase/debug/002_promote_user_to_manager.sql
@@ -1,0 +1,11 @@
+-- ============================================
+-- Promote a specific user to 'manager'
+-- ============================================
+
+-- Replace 'someone@yourcompany.com' with the actual email you want to promote
+update public.user_profiles
+set role = 'manager'
+where id = (
+  select id from auth.users
+  where email = 'someone@yourcompany.com'
+);

--- a/supabase/debug/003_grant_message_perms_to_user.sql
+++ b/supabase/debug/003_grant_message_perms_to_user.sql
@@ -1,0 +1,21 @@
+-- ============================================
+-- Grant message permissions to a specific user
+-- ============================================
+-- Replace 'someone@yourcompany.com' and 'client_abc'
+-- with the actual email and client_id.
+
+-- Grant edit_all_messages
+insert into public.user_permission_grants (user_id, perm, client_id)
+select up.id, 'edit_all_messages', 'client_abc'
+from public.user_profiles up
+join auth.users u on u.id = up.id
+where u.email = 'someone@yourcompany.com'
+on conflict do nothing;
+
+-- Grant delete_all_messages
+insert into public.user_permission_grants (user_id, perm, client_id)
+select up.id, 'delete_all_messages', 'client_abc'
+from public.user_profiles up
+join auth.users u on u.id = up.id
+where u.email = 'someone@yourcompany.com'
+on conflict do nothing;

--- a/supabase/debug/004_grant_global_message_perms.sql
+++ b/supabase/debug/004_grant_global_message_perms.sql
@@ -1,0 +1,21 @@
+-- ============================================
+-- Grant global message permissions to a user
+-- ============================================
+-- Replace 'someone@yourcompany.com' with the actual email.
+-- client_id = null → permission applies across all clients.
+
+-- Grant edit_all_messages (global)
+insert into public.user_permission_grants (user_id, perm, client_id)
+select up.id, 'edit_all_messages', null
+from public.user_profiles up
+join auth.users u on u.id = up.id
+where u.email = 'someone@yourcompany.com'
+on conflict do nothing;
+
+-- Grant delete_all_messages (global)
+insert into public.user_permission_grants (user_id, perm, client_id)
+select up.id, 'delete_all_messages', null
+from public.user_profiles up
+join auth.users u on u.id = up.id
+where u.email = 'someone@yourcompany.com'
+on conflict do nothing;

--- a/supabase/debug/005_view_all_permission_grants.sql
+++ b/supabase/debug/005_view_all_permission_grants.sql
@@ -1,0 +1,14 @@
+-- ============================================================
+-- Debug helper: inspect all user permission grants with emails
+-- ============================================================
+
+-- Ensure view exists and is up to date
+create or replace view public.my_perms as
+select g.*, u.email
+from public.user_permission_grants g
+join auth.users u on u.id = g.user_id;
+
+-- See all grants in a friendly order
+select * 
+from public.my_perms
+order by email, perm, client_id;

--- a/supabase/debug/README.md
+++ b/supabase/debug/README.md
@@ -1,0 +1,8 @@
+# supabase/debug
+
+Contains ad-hoc queries and helper scripts for debugging.
+
+- `select_user.sql` → Look up a profile + role by email.
+- `my_perms.sql` → List all permission grants by email.
+
+These are safe to keep around for troubleshooting but not part of migrations.

--- a/supabase/seed/001_seed_messages.sql
+++ b/supabase/seed/001_seed_messages.sql
@@ -1,0 +1,110 @@
+-- 003_seed_messages.sql
+-- Seed sample messages, tags, and read-status using real IDs from your DB (idempotent)
+-- Date: 2025-08-15
+-- Notes:
+--   - Picks existing client/contact IDs from public.user_profiles
+--   - Inserts three demo messages only if they don't already exist (based on unique titles)
+--   - Adds tags and read-status rows conditionally
+
+-- Helper CTEs to pick real contacts from user_profiles
+with
+  c1 as (
+    select up.client_id, up.contact_id
+    from public.user_profiles up
+    where up.contact_id is not null
+    limit 1
+  ),
+  c2 as (
+    select up.client_id, up.contact_id
+    from public.user_profiles up
+    where up.contact_id is not null
+      and (up.client_id, up.contact_id) not in (select client_id, contact_id from c1)
+    limit 1
+  ),
+  c3 as (
+    -- Prefer a different client if available; otherwise reuse c1's client/contact
+    select up.client_id, up.contact_id
+    from public.user_profiles up
+    where up.contact_id is not null
+      and up.client_id <> (select client_id from c1)
+    limit 1
+  ),
+  chosen as (
+    select
+      (select client_id from c1) as client1,
+      (select contact_id from c1) as contact1,
+      coalesce((select client_id from c2), (select client_id from c1)) as client2,
+      coalesce((select contact_id from c2), (select contact_id from c1)) as contact2,
+      coalesce((select client_id from c3), (select client_id from c1)) as client3,
+      coalesce((select contact_id from c3), (select contact_id from c1)) as contact3
+  )
+
+-- 1) Messages (insert if not already present by title)
+insert into public.messages (client_id, contact_id, title, body, visibility)
+select client1, contact1, 'Project Kickoff', 'We are starting the project today.', 'shared'
+from chosen
+where not exists (select 1 from public.messages where title = 'Project Kickoff');
+
+insert into public.messages (client_id, contact_id, title, body, visibility)
+select client2, contact2, 'Internal Planning', 'This is an internal-only update.', 'internal'
+from chosen
+where not exists (select 1 from public.messages where title = 'Internal Planning');
+
+insert into public.messages (client_id, contact_id, title, body, visibility)
+select client3, contact3, 'Q3 Review', 'Here are the results from the last quarter.', 'public'
+from chosen
+where not exists (select 1 from public.messages where title = 'Q3 Review');
+
+-- 2) Tags for first message (only if not already present)
+insert into public.message_tags (message_id, tag)
+select m.id, 'kickoff'
+from public.messages m
+where m.title = 'Project Kickoff'
+  and not exists (
+    select 1 from public.message_tags t where t.message_id = m.id and t.tag = 'kickoff'
+  );
+
+insert into public.message_tags (message_id, tag)
+select m.id, 'priority'
+from public.messages m
+where m.title = 'Project Kickoff'
+  and not exists (
+    select 1 from public.message_tags t where t.message_id = m.id and t.tag = 'priority'
+  );
+
+-- 3) Read-status recipients (choose different contacts when possible)
+with
+  base as (
+    select m.id as message_id from public.messages m where m.title = 'Project Kickoff' limit 1
+  ),
+  reader1 as (
+    select up.contact_id
+    from public.user_profiles up
+    where up.contact_id is not null
+    limit 1
+  ),
+  reader2 as (
+    select up.contact_id
+    from public.user_profiles up
+    where up.contact_id is not null
+      and up.contact_id <> (select contact_id from reader1)
+    limit 1
+  )
+insert into public.message_contacts (message_id, contact_id, read_at)
+select (select message_id from base), (select contact_id from reader1), null
+where exists (select 1 from base)
+  and not exists (
+    select 1 from public.message_contacts mc
+    where mc.message_id = (select message_id from base)
+      and mc.contact_id = (select contact_id from reader1)
+  );
+
+insert into public.message_contacts (message_id, contact_id, read_at)
+select (select message_id from base), (select contact_id from reader2), now()
+where exists (select 1 from base)
+  and (select contact_id from reader2) is not null
+  and not exists (
+    select 1 from public.message_contacts mc
+    where mc.message_id = (select message_id from base)
+      and mc.contact_id = (select contact_id from reader2)
+  );

--- a/supabase/seed/002_seed_permissions.sql
+++ b/supabase/seed/002_seed_permissions.sql
@@ -1,0 +1,15 @@
+-- Seed example: grant edit/delete perms to daniel@test.com for client_abc
+
+insert into public.user_permission_grants (user_id, perm, client_id)
+select up.id, 'edit_all_messages', 'client_abc'
+from public.user_profiles up
+join auth.users u on u.id = up.id
+where u.email = 'daniel@test.com'
+on conflict do nothing;
+
+insert into public.user_permission_grants (user_id, perm, client_id)
+select up.id, 'delete_all_messages', 'client_abc'
+from public.user_profiles up
+join auth.users u on u.id = up.id
+where u.email = 'daniel@test.com'
+on conflict do nothing;

--- a/supabase/seed/README.md
+++ b/supabase/seed/README.md
@@ -1,0 +1,19 @@
+# Seed Data
+
+This folder contains **sample data** for development and testing.  
+These scripts are **not required in production**.
+
+## Rules
+- Number independently from schema, e.g. `001_*`, `002_*`.
+- Safe to delete/reset between test runs.
+- Only insert rows, never alter schema.
+
+## Example
+- `001_seed_messages.sql`
+
+## How to apply
+Run inside Supabase SQL Editor or via CLI:
+
+```bash
+supabase db remote commit
+```

--- a/supabase/sql/000_baseline_guardrails.sql
+++ b/supabase/sql/000_baseline_guardrails.sql
@@ -1,0 +1,180 @@
+-- 000_baseline_guardrails.sql
+-- Purpose: Make any environment "safe" for the current Tellari app, without dropping data.
+-- Idempotent: YES (uses IF EXISTS/IF NOT EXISTS/CREATE OR REPLACE)
+-- What this does:
+--  - Ensures required tables/columns exist (contacts, projects, messages.project_id)
+--  - Enables RLS where required
+--  - Ensures helpful indexes exist
+--  - (Re)creates permission helpers: has_perm(), has_perm_rpc()
+--  - (Re)creates the feed view: message_feed_v1
+--  - Ensures Supabase Realtime publication includes feed tables
+--  - (Optional) Permission-based RLS policies are provided but COMMENTED OUT so you can stage them
+
+------------------------------
+-- 1) Core tables & columns --
+------------------------------
+
+-- contacts
+create table if not exists public.contacts (
+  id text primary key,
+  client_id text not null,
+  name text not null,
+  email text null,
+  avatar_url text null,
+  created_at timestamptz not null default now()
+);
+create index if not exists contacts_client_id_idx on public.contacts(client_id);
+
+-- projects
+create table if not exists public.projects (
+  id text primary key,
+  client_id text not null,
+  name text not null,
+  created_at timestamptz not null default now()
+);
+create index if not exists projects_client_id_idx on public.projects(client_id);
+
+-- messages base table (must already exist from earlier migrations)
+-- add project_id column safely + FK
+alter table if exists public.messages
+  add column if not exists project_id text;
+do $$
+begin
+  alter table public.messages
+    add constraint messages_project_id_fkey
+    foreign key (project_id) references public.projects(id)
+    on delete set null;
+exception
+  when duplicate_object then null;
+end $$;
+
+-- helpful indexes (safe to (re)create)
+create index if not exists messages_client_created_idx on public.messages(client_id, created_at desc);
+create index if not exists messages_project_created_idx on public.messages(project_id, created_at desc);
+
+------------------------------------
+-- 2) Row Level Security switches --
+------------------------------------
+-- (Make sure RLS is enabled on core tables)
+alter table if exists public.messages enable row level security;
+alter table if exists public.message_tags enable row level security;
+alter table if exists public.message_contacts enable row level security;
+
+------------------------------------
+-- 3) Permission primitives       --
+------------------------------------
+create table if not exists public.permission_kinds (
+  perm text primary key
+);
+insert into public.permission_kinds (perm) values
+  ('manage_clients'),
+  ('edit_all_messages'),
+  ('delete_all_messages'),
+  ('manage_tasks'),
+  ('manage_files')
+on conflict do nothing;
+
+create table if not exists public.user_permission_grants (
+  user_id uuid not null references auth.users on delete cascade,
+  perm text not null references public.permission_kinds(perm) on delete cascade,
+  client_id text null,
+  primary key (user_id, perm, client_id)
+);
+
+create or replace function public.has_perm(uid uuid, p text, target_client_id text default null)
+returns boolean
+language sql
+stable
+as $$
+  select
+    exists (
+      select 1 from public.user_profiles up
+      where up.id = uid and up.role = 'admin'
+    )
+    or exists (
+      select 1 from public.user_permission_grants g
+      where g.user_id = uid
+        and g.perm = p
+        and (g.client_id is null or g.client_id = coalesce(target_client_id, g.client_id))
+    );
+$$;
+
+create or replace function public.has_perm_rpc(p text, target_client_id text default null)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.has_perm(auth.uid(), p, target_client_id);
+$$;
+grant execute on function public.has_perm_rpc(text, text) to anon, authenticated;
+
+------------------------------------
+-- 4) Feed view (enriched)       --
+------------------------------------
+create or replace view public.message_feed_v1 as
+select
+  m.id,
+  m.created_at,
+  m.client_id,
+  m.project_id,
+  p.name as project_name,
+  m.contact_id,
+  c.name as author_name,
+  c.email as author_email,
+  c.avatar_url,
+  m.title,
+  m.body,
+  m.visibility,
+  coalesce(mt.tags, array[]::text[]) as tags
+from public.messages m
+left join public.contacts c on c.id = m.contact_id
+left join public.projects p on p.id = m.project_id
+left join lateral (
+  select array_agg(t.tag order by t.tag) as tags
+  from public.message_tags t
+  where t.message_id = m.id
+) mt on true;
+
+--------------------------------------------------
+-- 5) Supabase Realtime publication (idempotent) --
+--------------------------------------------------
+-- These will no-op if already added.
+alter publication supabase_realtime add table public.messages;
+alter publication supabase_realtime add table public.message_tags;
+alter publication supabase_realtime add table public.message_contacts;
+
+--------------------------------------------------
+-- 6) (Optional) Permission-based RLS policies  --
+--------------------------------------------------
+-- Uncomment when ready to enforce with has_perm().
+-- NOTE: Keep your author/owner policies alongside these.
+/*
+drop policy if exists "messages_update_perm" on public.messages;
+create policy "messages_update_perm"
+on public.messages for update to authenticated
+using ( public.has_perm(auth.uid(), 'edit_all_messages', public.messages.client_id) )
+with check (true);
+
+drop policy if exists "messages_delete_perm" on public.messages;
+create policy "messages_delete_perm"
+on public.messages for delete to authenticated
+using ( public.has_perm(auth.uid(), 'delete_all_messages', public.messages.client_id) );
+
+drop policy if exists "message_tags_insert_perm" on public.message_tags;
+create policy "message_tags_insert_perm"
+on public.message_tags for insert to authenticated
+with check ( public.has_perm(auth.uid(), 'edit_all_messages') );
+
+drop policy if exists "message_tags_update_perm" on public.message_tags;
+create policy "message_tags_update_perm"
+on public.message_tags for update to authenticated
+using ( public.has_perm(auth.uid(), 'edit_all_messages') )
+with check (true);
+
+drop policy if exists "message_tags_delete_perm" on public.message_tags;
+create policy "message_tags_delete_perm"
+on public.message_tags for delete to authenticated
+using ( public.has_perm(auth.uid(), 'delete_all_messages') );
+*/

--- a/supabase/sql/001_user_profiles.sql
+++ b/supabase/sql/001_user_profiles.sql
@@ -1,0 +1,23 @@
+-- 001_user_profiles.sql
+-- Migration: Create user_profiles table linked to auth.users
+-- Date: 2025-08-15
+-- Description:
+--   - Extends auth.users with profile data
+--   - Adds contact_id, client_id, and role
+--   - Enables Row Level Security (RLS)
+--   - Policy allows users to read their own profile only
+
+-- Create a table to extend the auth.users table
+create table public.user_profiles (
+  id uuid primary key references auth.users on delete cascade,
+  contact_id text not null,
+  client_id text not null,
+  role text check (role in ('admin', 'client')) not null
+);
+
+-- Enable RLS
+alter table public.user_profiles enable row level security;
+
+-- Policy: user can read their own profile
+create policy "Users can access their own profile" on public.user_profiles
+  for select using (auth.uid() = id);

--- a/supabase/sql/002_messages.sql
+++ b/supabase/sql/002_messages.sql
@@ -1,0 +1,82 @@
+-- 002_messages.sql
+
+-- 1. Main messages table
+create table if not exists public.messages (
+  id uuid primary key default gen_random_uuid(),
+  client_id text not null,
+  contact_id text, -- sender contact (optional if system-generated)
+  title text, -- optional subject line
+  body text not null,
+  visibility text not null default 'shared'
+    check (visibility in ('internal', 'shared', 'public')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Auto-update updated_at on any edit
+create or replace function update_updated_at_column()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists set_updated_at on public.messages;
+create trigger set_updated_at
+before update on public.messages
+for each row
+execute function update_updated_at_column();
+
+-- 2. Tags for messages
+create table if not exists public.message_tags (
+  message_id uuid references public.messages on delete cascade,
+  tag text not null,
+  primary key (message_id, tag)
+);
+
+-- 3. Recipients (contact-level targeting + read status)
+create table if not exists public.message_contacts (
+  message_id uuid references public.messages on delete cascade,
+  contact_id text not null,
+  read_at timestamptz,
+  primary key (message_id, contact_id)
+);
+
+-- Optional: 4. Multi-client targeting (only if a message can belong to more than one client)
+create table if not exists public.message_clients (
+  message_id uuid references public.messages on delete cascade,
+  client_id text not null,
+  primary key (message_id, client_id)
+);
+
+-- 5. Row Level Security
+alter table public.messages enable row level security;
+alter table public.message_tags enable row level security;
+alter table public.message_contacts enable row level security;
+alter table public.message_clients enable row level security;
+
+-- Admins see all messages
+drop policy if exists "Admins see all messages" on public.messages;
+create policy "Admins see all messages"
+on public.messages for select
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+    and up.role = 'admin'
+  )
+);
+
+-- Clients see only their shared/public messages
+drop policy if exists "Clients see shared/public messages" on public.messages;
+create policy "Clients see shared/public messages"
+on public.messages for select
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+    and up.client_id = messages.client_id
+  )
+  and visibility in ('shared', 'public')
+);

--- a/supabase/sql/003_message_policies.sql
+++ b/supabase/sql/003_message_policies.sql
@@ -1,0 +1,97 @@
+-- 003_message_policies.sql
+-- Message policies (merged insert, read, tag, recipient policies)
+
+-- Admins can insert any message
+create policy if not exists "Admins can insert any message"
+on public.messages for insert to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+-- Clients can insert their own shared/public messages
+create policy if not exists "Clients can insert their own shared/public messages"
+on public.messages for insert to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.client_id = messages.client_id
+      and up.contact_id = messages.contact_id
+  )
+  and visibility in ('shared','public')
+);
+
+-- READ policies for tags/recipients
+create policy if not exists "Admins read all tags"
+on public.message_tags for select to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+create policy if not exists "Clients read tags for their visible messages"
+on public.message_tags for select to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.client_id = (select m.client_id from public.messages m where m.id = message_id)
+  )
+);
+
+create policy if not exists "Admins read all message_contacts"
+on public.message_contacts for select to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+create policy if not exists "Clients read their own recipient rows"
+on public.message_contacts for select to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.contact_id = message_contacts.contact_id
+  )
+);
+
+-- INSERT tag rows (admins)
+create policy if not exists "Admins can tag any message"
+on public.message_tags for insert to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+-- UPDATE read status for the viewing contact
+create policy if not exists "Contacts can mark their reads"
+on public.message_contacts for update to authenticated
+using (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.contact_id = message_contacts.contact_id
+  )
+)
+with check (true);
+
+-- Allow a user to INSERT a recipient row for themselves
+create policy if not exists "Contacts can insert their own recipient rows"
+on public.message_contacts for insert to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.contact_id = message_contacts.contact_id
+  )
+);

--- a/supabase/sql/004_enable_realtime.sql
+++ b/supabase/sql/004_enable_realtime.sql
@@ -1,0 +1,4 @@
+-- Ensure realtime is on for these tables
+alter publication supabase_realtime add table public.messages;
+alter publication supabase_realtime add table public.message_tags;
+alter publication supabase_realtime add table public.message_contacts;

--- a/supabase/sql/005_message_insert_policies.sql
+++ b/supabase/sql/005_message_insert_policies.sql
@@ -1,0 +1,48 @@
+-- 008_message_insert_policies.sql
+-- Refined INSERT policies for messages and message_contacts
+-- Drops existing versions if present, then recreates.
+
+-- Drop old policies (ignore errors if not existing)
+drop policy if exists "Admins can insert any message" on public.messages;
+drop policy if exists "Clients can insert their own shared/public messages" on public.messages;
+drop policy if exists "Contacts can insert their own recipient rows" on public.message_contacts;
+
+-- Admins can insert any message
+create policy "Admins can insert any message"
+on public.messages
+for insert
+to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid() and up.role = 'admin'
+  )
+);
+
+-- Clients can insert their own shared/public messages
+create policy "Clients can insert their own shared/public messages"
+on public.messages
+for insert
+to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.client_id = messages.client_id
+      and up.contact_id = messages.contact_id
+  )
+  and visibility in ('shared','public')
+);
+
+-- Contacts can insert their own recipient rows (mark-as-read)
+create policy "Contacts can insert their own recipient rows"
+on public.message_contacts
+for insert
+to authenticated
+with check (
+  exists (
+    select 1 from public.user_profiles up
+    where up.id = auth.uid()
+      and up.contact_id = message_contacts.contact_id
+  )
+);

--- a/supabase/sql/006_message_update_delete_policies.sql
+++ b/supabase/sql/006_message_update_delete_policies.sql
@@ -1,0 +1,132 @@
+-- 009_message_update_delete_policies.sql
+-- ================================
+-- MESSAGES: UPDATE / DELETE
+-- ================================
+drop policy if exists "Admins update messages" on public.messages;
+drop policy if exists "Admins delete messages" on public.messages;
+drop policy if exists "Clients update own messages" on public.messages;
+drop policy if exists "Clients delete own messages" on public.messages;
+
+-- Admins can UPDATE any message
+create policy "Admins update messages"
+on public.messages
+for update
+to authenticated
+using (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid() and up.role = 'admin')
+)
+with check (true);
+
+-- Admins can DELETE any message
+create policy "Admins delete messages"
+on public.messages
+for delete
+to authenticated
+using (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid() and up.role = 'admin')
+);
+
+-- Clients can UPDATE messages they authored (same client + same sender contact)
+create policy "Clients update own messages"
+on public.messages
+for update
+to authenticated
+using (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid()
+            and up.client_id = messages.client_id
+            and up.contact_id = messages.contact_id)
+)
+with check (true);
+
+-- Clients can DELETE messages they authored (same client + same sender contact)
+create policy "Clients delete own messages"
+on public.messages
+for delete
+to authenticated
+using (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid()
+            and up.client_id = messages.client_id
+            and up.contact_id = messages.contact_id)
+);
+
+-- ================================
+-- MESSAGE_TAGS: INSERT / UPDATE / DELETE (admins only for write)
+-- ================================
+drop policy if exists "Admins insert tags" on public.message_tags;
+drop policy if exists "Admins update tags" on public.message_tags;
+drop policy if exists "Admins delete tags" on public.message_tags;
+
+-- Admins can INSERT tags
+create policy "Admins insert tags"
+on public.message_tags
+for insert
+to authenticated
+with check (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid() and up.role = 'admin')
+);
+
+-- Admins can UPDATE tags
+create policy "Admins update tags"
+on public.message_tags
+for update
+to authenticated
+using (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid() and up.role = 'admin')
+)
+with check (true);
+
+-- Admins can DELETE tags
+create policy "Admins delete tags"
+on public.message_tags
+for delete
+to authenticated
+using (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid() and up.role = 'admin')
+);
+
+-- ================================
+-- MESSAGE_CONTACTS: INSERT (self), UPDATE read_at (self), DELETE (admin)
+-- ================================
+drop policy if exists "Contacts can insert their own recipient rows" on public.message_contacts;
+drop policy if exists "Contacts can mark their reads" on public.message_contacts;
+drop policy if exists "Admins manage message_contacts" on public.message_contacts;
+
+-- Allow a user to INSERT their own recipient row (for first "Mark as read")
+create policy "Contacts can insert their own recipient rows"
+on public.message_contacts
+for insert
+to authenticated
+with check (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid()
+            and up.contact_id = message_contacts.contact_id)
+);
+
+-- Allow a user to UPDATE their own recipient row (set read_at)
+create policy "Contacts can mark their reads"
+on public.message_contacts
+for update
+to authenticated
+using (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid()
+            and up.contact_id = message_contacts.contact_id)
+)
+with check (true);
+
+-- Admins can clean up recipient rows (optional but handy)
+create policy "Admins manage message_contacts"
+on public.message_contacts
+for delete
+to authenticated
+using (
+  exists (select 1 from public.user_profiles up
+          where up.id = auth.uid() and up.role = 'admin')
+);

--- a/supabase/sql/007_permissions_and_has_perm.sql
+++ b/supabase/sql/007_permissions_and_has_perm.sql
@@ -1,0 +1,55 @@
+-- ================================
+-- PERMISSIONS: Kinds + Grants + Helper
+-- ================================
+
+-- Catalog of permission names
+create table if not exists public.permission_kinds (
+  perm text primary key
+);
+
+insert into public.permission_kinds (perm)
+values
+  ('manage_clients'),
+  ('edit_all_messages'),
+  ('delete_all_messages'),
+  ('manage_tasks'),
+  ('manage_files')
+on conflict do nothing;
+
+-- Grants: which user has which permission (optionally scoped to a client_id)
+create table if not exists public.user_permission_grants (
+  user_id uuid not null references auth.users on delete cascade,
+  perm text not null references public.permission_kinds(perm) on delete cascade,
+  client_id text null,
+  primary key (user_id, perm, client_id)
+);
+
+-- Helper function: has_perm(uid, perm, target_client_id)
+-- Admins automatically get everything
+-- Managers/staff get only what is granted
+create or replace function public.has_perm(uid uuid, p text, target_client_id text default null)
+returns boolean
+language sql
+stable
+as $$
+  select
+    -- Admins get everything by default
+    exists (
+      select 1 from public.user_profiles up
+      where up.id = uid and up.role = 'admin'
+    )
+    or
+    -- Or permission explicitly granted
+    exists (
+      select 1 from public.user_permission_grants g
+      where g.user_id = uid
+        and g.perm = p
+        and (g.client_id is null or g.client_id = coalesce(target_client_id, g.client_id))
+    );
+$$;
+
+-- Optional: Debug view to inspect granted perms
+create or replace view public.my_perms as
+select g.*, u.email
+from public.user_permission_grants g
+join auth.users u on u.id = g.user_id;

--- a/supabase/sql/008_has_perm_rpc.sql
+++ b/supabase/sql/008_has_perm_rpc.sql
@@ -1,0 +1,20 @@
+-- ================================
+-- HAS_PERM RPC WRAPPER
+-- ================================
+
+-- Expose has_perm() to clients through an RPC
+-- This lets the app call supabase.rpc('has_perm_rpc', { p: 'edit_all_messages', target_client_id: 'xyz' })
+-- and automatically checks permissions for the logged-in user.
+
+create or replace function public.has_perm_rpc(p text, target_client_id text default null)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.has_perm(auth.uid(), p, target_client_id);
+$$;
+
+-- Allow both anon and authenticated roles to call this RPC
+grant execute on function public.has_perm_rpc(text, text) to anon, authenticated;

--- a/supabase/sql/009_messages_permissions.sql
+++ b/supabase/sql/009_messages_permissions.sql
@@ -1,0 +1,49 @@
+-- 012_messages_permissions.sql
+-- Purpose: apply fine‑grained permissions using has_perm() to messages, tags, and message_contacts
+-- Prereqs: 010_permissions_and_has_perm.sql, 011_has_perm_rpc.sql
+
+-- ================================
+-- MESSAGES: UPDATE / DELETE via permissions
+-- ================================
+drop policy if exists "Admins update messages" on public.messages;
+drop policy if exists "Admins delete messages" on public.messages;
+
+create policy "Users with 'edit_all_messages' can update"
+on public.messages for update to authenticated
+using ( public.has_perm(auth.uid(), 'edit_all_messages', messages.client_id) )
+with check (true);
+
+create policy "Users with 'delete_all_messages' can delete"
+on public.messages for delete to authenticated
+using ( public.has_perm(auth.uid(), 'delete_all_messages', messages.client_id) );
+
+-- Keep your “Clients update/delete own messages” policies (already created) – do not remove them.
+
+-- ================================
+-- MESSAGE_TAGS: write actions via permissions (previously admin-only)
+-- ================================
+drop policy if exists "Admins insert tags" on public.message_tags;
+drop policy if exists "Admins update tags" on public.message_tags;
+drop policy if exists "Admins delete tags" on public.message_tags;
+
+create policy "Users with 'edit_all_messages' can insert tags"
+on public.message_tags for insert to authenticated
+with check ( public.has_perm(auth.uid(), 'edit_all_messages') );
+
+create policy "Users with 'edit_all_messages' can update tags"
+on public.message_tags for update to authenticated
+using ( public.has_perm(auth.uid(), 'edit_all_messages') )
+with check (true);
+
+create policy "Users with 'delete_all_messages' can delete tags"
+on public.message_tags for delete to authenticated
+using ( public.has_perm(auth.uid(), 'delete_all_messages') );
+
+-- ================================
+-- MESSAGE_CONTACTS: cleanup via permission (optional)
+-- ================================
+drop policy if exists "Admins manage message_contacts" on public.message_contacts;
+
+create policy "Users with 'edit_all_messages' can cleanup message_contacts"
+on public.message_contacts for delete to authenticated
+using ( public.has_perm(auth.uid(), 'edit_all_messages') );

--- a/supabase/sql/010_user_profiles_add_manager.sql
+++ b/supabase/sql/010_user_profiles_add_manager.sql
@@ -1,0 +1,28 @@
+-- ================================================
+-- Add "manager" role to user_profiles
+-- ================================================
+
+-- 1) Drop the existing CHECK constraint on user_profiles.role (name may vary)
+do $$
+declare
+  cname text;
+begin
+  select conname
+  into cname
+  from pg_constraint
+  where conrelid = 'public.user_profiles'::regclass
+    and contype = 'c'
+    and pg_get_constraintdef(oid) ilike '%role in (%';
+
+  if cname is not null then
+    execute format('alter table public.user_profiles drop constraint %I', cname);
+  end if;
+end $$;
+
+-- 2) Add a new CHECK that includes 'manager'
+alter table public.user_profiles
+  add constraint user_profiles_role_check
+  check (role in ('admin','client','manager'));
+
+-- (Optional) If you want managers to be the default for new internal users (usually keep 'client'):
+-- alter table public.user_profiles alter column role set default 'client';

--- a/supabase/sql/011_user_profiles_role_check_reset.sql
+++ b/supabase/sql/011_user_profiles_role_check_reset.sql
@@ -1,0 +1,13 @@
+-- ================================================
+-- Reset user_profiles.role CHECK constraint
+-- (explicitly re-creates it with admin, manager, client)
+-- ================================================
+
+-- Drop the existing role check constraint
+ALTER TABLE public.user_profiles
+DROP CONSTRAINT IF EXISTS user_profiles_role_check;
+
+-- Recreate it with the new role set
+ALTER TABLE public.user_profiles
+ADD CONSTRAINT user_profiles_role_check
+CHECK (role IN ('admin', 'manager', 'client'));

--- a/supabase/sql/012_permissions_and_rls_update.sql
+++ b/supabase/sql/012_permissions_and_rls_update.sql
@@ -1,0 +1,102 @@
+-- ============================================
+-- PERMISSIONS + RLS UPDATE (roll-up migration)
+-- ============================================
+
+-- ====== PERMISSIONS PRIMITIVES ======
+
+-- 1) Catalog of permission names (idempotent)
+create table if not exists public.permission_kinds (
+  perm text primary key
+);
+
+insert into public.permission_kinds (perm)
+values
+  ('manage_clients'),
+  ('edit_all_messages'),
+  ('delete_all_messages'),
+  ('manage_tasks'),
+  ('manage_files')
+on conflict do nothing;
+
+-- 2) Grants: who has which permission, optionally scoped by client_id
+create table if not exists public.user_permission_grants (
+  user_id uuid not null references auth.users on delete cascade,
+  perm text not null references public.permission_kinds(perm) on delete cascade,
+  client_id text null,
+  primary key (user_id, perm, client_id)
+);
+
+-- 3) Helper: 'admin' users implicitly have all perms; otherwise check explicit grants
+create or replace function public.has_perm(uid uuid, p text, target_client_id text default null)
+returns boolean
+language sql
+stable
+as $$
+  select
+    -- admins get everything by default
+    exists (
+      select 1 from public.user_profiles up
+      where up.id = uid and up.role = 'admin'
+    )
+    or
+    -- OR permission explicitly granted (optionally scoped to client)
+    exists (
+      select 1 from public.user_permission_grants g
+      where g.user_id = uid
+        and g.perm = p
+        and (g.client_id is null or g.client_id = coalesce(target_client_id, g.client_id))
+    );
+$$;
+
+-- 4) RPC wrapper so the app can call has_perm() easily
+create or replace function public.has_perm_rpc(p text, target_client_id text default null)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.has_perm(auth.uid(), p, target_client_id);
+$$;
+
+grant execute on function public.has_perm_rpc(text, text) to anon, authenticated;
+
+-- ====== RLS UPDATES (admin-only paths -> permission-based) ======
+
+-- messages: UPDATE / DELETE require edit/delete perms (owner policies stay untouched)
+drop policy if exists "Admins update messages" on public.messages;
+drop policy if exists "Admins delete messages" on public.messages;
+
+create policy "Perm: edit_all_messages can update"
+on public.messages for update to authenticated
+using ( public.has_perm(auth.uid(), 'edit_all_messages', messages.client_id) )
+with check ( true );
+
+create policy "Perm: delete_all_messages can delete"
+on public.messages for delete to authenticated
+using ( public.has_perm(auth.uid(), 'delete_all_messages', messages.client_id) );
+
+-- message_tags: insert/update/delete require edit/delete perms
+drop policy if exists "Admins insert tags" on public.message_tags;
+drop policy if exists "Admins update tags" on public.message_tags;
+drop policy if exists "Admins delete tags" on public.message_tags;
+
+create policy "Perm: edit_all_messages can insert tags"
+on public.message_tags for insert to authenticated
+with check ( public.has_perm(auth.uid(), 'edit_all_messages') );
+
+create policy "Perm: edit_all_messages can update tags"
+on public.message_tags for update to authenticated
+using ( public.has_perm(auth.uid(), 'edit_all_messages') )
+with check ( true );
+
+create policy "Perm: delete_all_messages can delete tags"
+on public.message_tags for delete to authenticated
+using ( public.has_perm(auth.uid(), 'delete_all_messages') );
+
+-- message_contacts: allow privileged cleanup (optional)
+drop policy if exists "Admins manage message_contacts" on public.message_contacts;
+
+create policy "Perm: edit_all_messages can cleanup message_contacts"
+on public.message_contacts for delete to authenticated
+using ( public.has_perm(auth.uid(), 'edit_all_messages') );

--- a/supabase/sql/013_permissions_with_optional_rls.sql
+++ b/supabase/sql/013_permissions_with_optional_rls.sql
@@ -1,0 +1,83 @@
+-- Permission catalog + helper (with optional RLS swaps)
+
+-- 1) Permission catalog
+create table if not exists public.permission_kinds (
+  perm text primary key
+);
+
+insert into public.permission_kinds (perm)
+values
+  ('manage_clients'),
+  ('edit_all_messages'),
+  ('delete_all_messages'),
+  ('manage_tasks'),
+  ('manage_files')
+on conflict do nothing;
+
+-- 2) Grants
+create table if not exists public.user_permission_grants (
+  user_id uuid not null references auth.users on delete cascade,
+  perm text not null references public.permission_kinds(perm) on delete cascade,
+  client_id text null,
+  primary key (user_id, perm, client_id)
+);
+
+-- 3) Helper: admins always pass; otherwise check grants (optionally by client)
+create or replace function public.has_perm(uid uuid, p text, target_client_id text default null)
+returns boolean
+language sql
+stable
+as $$
+  select
+    exists (select 1 from public.user_profiles up where up.id = uid and up.role = 'admin')
+    or exists (
+      select 1 from public.user_permission_grants g
+      where g.user_id = uid
+        and g.perm = p
+        and (g.client_id is null or g.client_id = coalesce(target_client_id, g.client_id))
+    );
+$$;
+
+-- 4) RPC wrapper for the app
+create or replace function public.has_perm_rpc(p text, target_client_id text default null)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.has_perm(auth.uid(), p, target_client_id);
+$$;
+
+grant execute on function public.has_perm_rpc(text, text) to anon, authenticated;
+
+-- ============================================================
+-- Optional RLS swaps you can add when ready
+-- (keeps current owner policies intact)
+-- ============================================================
+
+-- Messages: update/delete via permissions (admin-only routes replaced)
+-- drop policy if exists "Admins update messages" on public.messages;
+-- drop policy if exists "Admins delete messages" on public.messages;
+-- create policy "Perm: edit_all_messages can update"
+-- on public.messages for update to authenticated
+-- using ( public.has_perm(auth.uid(), 'edit_all_messages', messages.client_id) )
+-- with check ( true );
+-- create policy "Perm: delete_all_messages can delete"
+-- on public.messages for delete to authenticated
+-- using ( public.has_perm(auth.uid(), 'delete_all_messages', messages.client_id) );
+
+-- Tags: insert/update/delete via permissions
+-- drop policy if exists "Admins insert tags" on public.message_tags;
+-- drop policy if exists "Admins update tags" on public.message_tags;
+-- drop policy if exists "Admins delete tags" on public.message_tags;
+-- create policy "Perm: edit_all_messages can insert tags"
+-- on public.message_tags for insert to authenticated
+-- with check ( public.has_perm(auth.uid(), 'edit_all_messages') );
+-- create policy "Perm: edit_all_messages can update tags"
+-- on public.message_tags for update to authenticated
+-- using ( public.has_perm(auth.uid(), 'edit_all_messages') )
+-- with check ( true );
+-- create policy "Perm: delete_all_messages can delete tags"
+-- on public.message_tags for delete to authenticated
+-- using ( public.has_perm(auth.uid(), 'delete_all_messages') );

--- a/supabase/sql/014_feed_contacts_projects_view.sql
+++ b/supabase/sql/014_feed_contacts_projects_view.sql
@@ -1,0 +1,102 @@
+-- =========================================
+-- Tellari Feed: contacts + projects + view
+-- Safe to re-run (idempotent)
+-- =========================================
+
+-- 0) CONTACTS TABLE (for author names/avatars)
+create table if not exists public.contacts (
+  id text primary key,              -- matches messages.contact_id and user_profiles.contact_id
+  client_id text not null,
+  name text not null,
+  email text null,
+  avatar_url text null,
+  created_at timestamptz not null default now()
+);
+
+-- Helpful index for lookups
+create index if not exists contacts_client_id_idx on public.contacts(client_id);
+
+-- 0a) SEED CONTACTS from user_profiles (preferred source)
+insert into public.contacts (id, client_id, name, email, avatar_url)
+select distinct on (up.contact_id)
+  up.contact_id,
+  up.client_id,
+  coalesce(u.email, up.contact_id) as name,
+  u.email as email,
+  null as avatar_url
+from public.user_profiles up
+left join auth.users u on u.id = up.id
+where up.contact_id is not null
+on conflict (id) do nothing;
+
+-- 0b) SEED CONTACTS from messages for any contact_ids not present yet
+insert into public.contacts (id, client_id, name, email, avatar_url)
+select distinct on (m.contact_id)
+  m.contact_id,
+  m.client_id,
+  coalesce(m.contact_id, 'contact') as name,
+  null as email,
+  null as avatar_url
+from public.messages m
+where m.contact_id is not null
+  and not exists (
+    select 1 from public.contacts c where c.id = m.contact_id
+  )
+on conflict (id) do nothing;
+
+-- 1) PROJECTS TABLE (if missing)
+create table if not exists public.projects (
+  id text primary key,
+  client_id text not null,
+  name text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists projects_client_id_idx on public.projects(client_id);
+
+-- 2) MESSAGES: add optional project_id + FK to projects
+alter table if exists public.messages
+  add column if not exists project_id text;
+
+do $$
+begin
+  alter table public.messages
+    add constraint messages_project_id_fkey
+    foreign key (project_id) references public.projects(id)
+    on delete set null;
+exception
+  when duplicate_object then null;
+end $$;
+
+-- Helpful feed indexes
+create index if not exists messages_client_created_idx on public.messages(client_id, created_at desc);
+create index if not exists messages_project_created_idx on public.messages(project_id, created_at desc);
+
+-- 3) FEED VIEW: author + avatar + project + tags flattened
+create or replace view public.message_feed_v1 as
+select
+  m.id,
+  m.created_at,
+  m.client_id,
+  m.project_id,
+  p.name as project_name,
+  m.contact_id,
+  c.name as author_name,
+  c.email as author_email,
+  c.avatar_url,
+  m.title,
+  m.body,
+  m.visibility,
+  coalesce(mt.tags, array[]::text[]) as tags
+from public.messages m
+left join public.contacts c on c.id = m.contact_id
+left join public.projects p on p.id = m.project_id
+left join lateral (
+  select array_agg(t.tag order by t.tag) as tags
+  from public.message_tags t
+  where t.message_id = m.id
+) mt on true;
+
+-- NOTE on RLS:
+-- Keep your existing RLS on base tables (messages, message_tags, message_contacts).
+-- You do NOT need to add RLS on this view; base-table RLS is enforced automatically on SELECTs via the view.

--- a/supabase/sql/README.md
+++ b/supabase/sql/README.md
@@ -1,0 +1,41 @@
+# supabase/sql
+
+This directory contains the **core schema and security policies** for Tellari.
+
+- **001_user_profiles.sql** → Extends `auth.users` with roles, client_id, contact_id.
+- **002_messages.sql** → Core `messages`, `message_tags`, `message_contacts`, `message_clients`.
+- **003_seed_messages.sql** → Example seed data (safe to leave in, skip in prod).
+- **004_message_policies.sql** → Read + insert policies for messages/tags/recipients.
+- **005_message_contacts_insert.sql** → Allow contacts to insert their own recipient row.
+- **006_realtime_publication.sql** → Enable Supabase Realtime on feed tables.
+- **007_debug_select_user.sql** → Quick helper to fetch a profile by email.
+- **008_message_policies_insert.sql** → Refined insert policies for admins & clients.
+- **009_message_policies_update_delete.sql** → Update/delete policies for messages & tags.
+- **010_permissions_and_has_perm.sql** → Permission catalog + grants + `has_perm()`.
+- **011_has_perm_rpc.sql** → RPC wrapper for permissions.
+- **012_message_policies_with_permissions.sql** → Replace admin-only policies with permission checks.
+- **013_grant_edit_delete.sql** → Example: grant edit/delete perms for a user.
+- **014_add_manager_role.sql** → Add `manager` as a valid role.
+- **015_fix_role_constraint.sql** → Constraint update for roles.
+- **016_permissions_primitives_full.sql** → Consolidated perms + RLS rewrite.
+- **017_promote_manager.sql** → Example: promote a user to `manager`.
+- **018_grant_perms_manager.sql** → Grant perms scoped to client for manager.
+- **019_grant_perms_global.sql** → Grant perms globally (all clients).
+- **020_my_perms_view.sql** → Debugging view of perms by user/email.
+- **021_feed_contacts_projects_view.sql** → Feed view with authors, avatars, projects.
+
+> ⚠️ These scripts are meant to be applied in order.  
+> If re-running on an existing DB, check for `drop` or `if not exists` clauses first.
+
+---
+
+### 📄 `supabase/seed/README.md`
+```markdown
+# supabase/seed
+
+Contains **example/demo data** to help with local testing.
+
+- Example messages and tags.
+- Example recipients/read statuses.
+
+Do **not** apply in production unless you want demo/test data.

--- a/supabase/sql/z99_sanity_checks.sql
+++ b/supabase/sql/z99_sanity_checks.sql
@@ -1,0 +1,79 @@
+-- z99_sanity_checks.sql
+-- Purpose: Quick report of required objects for Tellari app.
+-- Run this any time to verify an environment is aligned with the app.
+
+-- 1) Tables present?
+select 'tables' as kind, t as name, 
+       case when exists (select 1 from information_schema.tables where table_schema='public' and table_name=t) then '✅' else '❌' end as ok
+from (values
+  ('user_profiles'),
+  ('messages'),
+  ('message_tags'),
+  ('message_contacts'),
+  ('contacts'),
+  ('projects'),
+  ('permission_kinds'),
+  ('user_permission_grants')
+) as v(t)
+order by t;
+
+-- 2) Critical columns present?
+select 'columns' as kind, tbl||'.'||col as name,
+       case when exists (
+         select 1 from information_schema.columns 
+         where table_schema='public' and table_name=tbl and column_name=col
+       ) then '✅' else '❌' end as ok
+from (values
+  ('user_profiles','id'),
+  ('user_profiles','client_id'),
+  ('user_profiles','contact_id'),
+  ('user_profiles','role'),
+  ('messages','id'),
+  ('messages','client_id'),
+  ('messages','contact_id'),
+  ('messages','project_id'),
+  ('messages','body'),
+  ('messages','visibility'),
+  ('messages','created_at'),
+  ('message_tags','message_id'),
+  ('message_tags','tag'),
+  ('message_contacts','message_id'),
+  ('message_contacts','contact_id'),
+  ('contacts','id'),
+  ('contacts','client_id'),
+  ('contacts','name'),
+  ('projects','id'),
+  ('projects','client_id'),
+  ('projects','name')
+) as c(tbl,col)
+order by tbl, col;
+
+-- 3) Functions present?
+select 'functions' as kind, name, 
+       case when exists (select 1 from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+                         where n.nspname='public' and p.proname=name) then '✅' else '❌' end as ok
+from (values
+  ('has_perm'),
+  ('has_perm_rpc')
+) as f(name)
+order by name;
+
+-- 4) View present?
+select 'views' as kind, name,
+       case when exists (select 1 from information_schema.views 
+                         where table_schema='public' and table_name=name) then '✅' else '❌' end as ok
+from (values
+  ('message_feed_v1')
+) as v(name);
+
+-- 5) RLS enabled on core tables?
+select 'rls_enabled' as kind, t as table_name,
+       case when relrowsecurity then '✅' else '❌' end as ok
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+join (values ('messages'), ('message_tags'), ('message_contacts')) as req(t) on req.t = c.relname
+where n.nspname='public'
+order by t;
+
+-- 6) Optional: show any missing items for quick copy/paste
+-- (Rows marked ❌ above indicate what to fix.)


### PR DESCRIPTION
Summary
This PR adds a full history of SQL files used to configure Tellari’s Supabase database, along with baseline guardrails and sanity checks. The goal is to ensure all schema changes are tracked in Git and reproducible from scratch.

✅ Changes

Added supabase/sql/ with 23 numbered migration scripts (user profiles, messages, tags, contacts, projects, permissions, RLS policies).

Added supabase/seed/ with seed data for testing (messages, tags, contacts).

Added supabase/debug/ with helper queries for quick troubleshooting (my_perms, user lookups, etc).

Added supabase/archive/ to retain legacy/alternate drafts of SQL for reference.

Added 000_baseline_guardrails.sql (ensures contacts/projects/messages columns exist, re-creates critical functions/views, resets RLS if needed).

Added z99_sanity_checks.sql (outputs ✅/❌ for existence of required tables, functions, views).

Added README.md files in each directory for clarity.